### PR TITLE
Disable static export and force dynamic rendering

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,8 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react"],
   },
+  output: "standalone",
+  staticPageGenerationTimeout: 120,
   reactStrictMode: true,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,16 +30,16 @@
         "@types/react-dom": "18.2.22",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
-        "autoprefixer": "10.4.17",
+        "autoprefixer": "10.4.20",
         "eslint": "8.57.0",
         "eslint-config-next": "14.1.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jsx-a11y": "6.8.0",
         "eslint-plugin-tailwindcss": "3.13.0",
-        "postcss": "8.4.35",
+        "postcss": "8.4.47",
         "prettier": "3.2.5",
-        "tailwindcss": "3.4.1",
+        "tailwindcss": "3.4.13",
         "typescript": "5.4.2",
         "vitest": "1.4.0"
       }
@@ -2990,9 +2990,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.17",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
-      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+      "version": "10.4.20",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+      "integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
       "dev": true,
       "funding": [
         {
@@ -3010,11 +3010,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.22.2",
-        "caniuse-lite": "^1.0.30001578",
+        "browserslist": "^4.23.3",
+        "caniuse-lite": "^1.0.30001646",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
+        "picocolors": "^1.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "bin": {
@@ -6539,9 +6539,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "version": "8.4.47",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
+      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6559,8 +6559,8 @@
       "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "picocolors": "^1.1.0",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -7737,9 +7737,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
+      "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -7750,7 +7750,7 @@
         "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
+        "jiti": "^1.21.0",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { unstable_noStore as noStore } from "next/cache";
+
 import { UsersExplorer } from "../components/UsersExplorer";
 
 export default function HomePage() {
+  noStore();
   return <UsersExplorer />;
 }

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -1,3 +1,7 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { unstable_noStore as noStore } from "next/cache";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -6,6 +10,7 @@ import { fetchUserById } from "../../../lib/okta/client";
 import { formatDisplay } from "../../../lib/utils";
 
 export default async function UserDetailsPage({ params }: { params: { id: string } }) {
+  noStore();
   const user = await fetchUserById(params.id);
   if (!user) {
     notFound();

--- a/src/lib/okta/client.ts
+++ b/src/lib/okta/client.ts
@@ -65,6 +65,7 @@ async function oktaFetch(path: string, options: FetchOptions = {}, attempt = 0):
   try {
     const response = await fetch(buildUrl(path), {
       ...options,
+      cache: "no-store",
       headers: {
         Accept: "application/json",
         Authorization: `SSWS ${OKTA_API_TOKEN}`,


### PR DESCRIPTION
## Summary
- configure Next.js to emit a standalone server build with an increased static page generation timeout to avoid export behavior
- force request-time rendering on the home and user detail pages while disabling cache reuse for Okta API calls

## Testing
- CI=1 npm run build

## Final instruction block
TASK=Your actual task description
Task description: Your actual task description

------
https://chatgpt.com/codex/tasks/task_e_68e656e72ae08331af96c2ea94310efd